### PR TITLE
Conditional caching in debug mode with key ignoring as regular expression

### DIFF
--- a/Cache.php
+++ b/Cache.php
@@ -4,11 +4,14 @@ namespace CodeMeme\CacheBundle;
 
 class Cache
 {
-
+    private $debug;
+    private $debugKeys;
     private $adapter;
 
-    public function __construct($adapter = null)
+    public function __construct($adapter = null, $debugKeys = array(), $debug = false)
     {
+        $this->debug = $debug;
+        $this->debugKeys = $debugKeys;
         $this->adapter = $adapter;
     }
 
@@ -26,6 +29,14 @@ class Cache
 
     public function get($keyOrObject)
     {
+        //if we're in debug mode and the key is in the debugkeys array return false
+        if ($this->debug) {
+            foreach ($this->debugKeys as $pattern) {
+                $match = preg_match($pattern, $keyOrObject);
+                if ($match) return false;
+            }
+        }
+        
         $key = $this->getKey($keyOrObject);
 
         // Get the expected expiration time

--- a/CacheFactory.php
+++ b/CacheFactory.php
@@ -5,12 +5,12 @@ namespace CodeMeme\CacheBundle;
 class CacheFactory
 {
 
-    public function createCache()
+    public function createCache($debugKeys = array(), $debug = false)
     {
         $adapter = new \Memcache;
         $adapter->connect('127.0.0.1');
         
-        return new Cache($adapter);
+        return new Cache($adapter, $debugKeys, $debug);
     }
 
 }

--- a/Resources/config/cache.xml
+++ b/Resources/config/cache.xml
@@ -7,10 +7,16 @@
     <parameters>
         <parameter key="cache.factory.class">CodeMeme\CacheBundle\CacheFactory</parameter>
         <parameter key="cache.class">CodeMeme\CacheBundle\Cache</parameter>
+        <parameter key="cache.debug.keys" type="collection" >
+            <parameter key="provider_config">/provider\..*\.config/i</parameter>
+        </parameter>
     </parameters>
 
     <services>
         <service id="cache.factory" class="%cache.factory.class%" />
-        <service id="cache" class="%cache.class%" factory-service="cache.factory" factory-method="createCache" />
+        <service id="cache" class="%cache.class%" factory-service="cache.factory" factory-method="createCache" >
+            <argument>%cache.debug.keys%</argument>
+            <argument>%kernel.debug%</argument>  
+        </service>
     </services>
 </container>


### PR DESCRIPTION
This adds a parameter on the CacheBundle extension that allows the definition of regular expressions to be used to exclude certain keys in cacheing. It also adds the kernel debug parameter and the cache debug keys as arguments to the cache factory service.

In the CacheFactory::createCache method the debugKeys and debug parameters are carried to the Cache object which uses them in the get method to filter the keys and return false ONLY if the debug flag is set. In production the filtering will not be executed.
